### PR TITLE
updated type for CONTENT to MEDIUMTEXT (was TEXT)

### DIFF
--- a/app/code/Magento/CheckoutAgreements/etc/db_schema.xml
+++ b/app/code/Magento/CheckoutAgreements/etc/db_schema.xml
@@ -11,7 +11,7 @@
         <column xsi:type="int" name="agreement_id" padding="10" unsigned="true" nullable="false" identity="true"
                 comment="Agreement ID"/>
         <column xsi:type="varchar" name="name" nullable="true" length="255" comment="Name"/>
-        <column xsi:type="text" name="content" nullable="true" comment="Content"/>
+        <column xsi:type="mediumtext" name="content" nullable="true" comment="Content"/>
         <column xsi:type="varchar" name="content_height" nullable="true" length="25" comment="Content Height"/>
         <column xsi:type="text" name="checkbox_text" nullable="true" comment="Checkbox Text"/>
         <column xsi:type="smallint" name="is_active" padding="6" unsigned="false" nullable="false" identity="false"


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Experienced cut-off text when adding long texts into the content. Because of very long GDPR paragraphs, its no more sufficient to only have 65k characters available. 
it is now also consistent to the module_cms > cms_page TABLE.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Adding text longer than 65k will cut off the text in the frontend

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
